### PR TITLE
Plot output tweaks

### DIFF
--- a/cytof_pipeline.R
+++ b/cytof_pipeline.R
@@ -1293,7 +1293,7 @@ pdf(file.path(out_dir, "batch_qc_plots.pdf"))
             breaks = breaksList, 
             color = my_palette_greens(length(breaksList)), 
             main = "File x Cluster: expression (arcsinh-log1p)",
-            border_color = NA
+            border_color = NA, silent = T
   )
   grid::grid.newpage()
   grid::grid.draw(p$gtable)

--- a/cytof_pipeline.R
+++ b/cytof_pipeline.R
@@ -1096,7 +1096,11 @@ ggarrange(plotlist = allPlots, nrow = 6, ncol = 7)
 dev.off()
 
 
-pdf(file.path(out_dir, "plots.pdf"))
+pdf(file.path(out_dir, "plots.pdf"),
+    # scale by the numbers of markers and clusters to ensure visibility
+    w = min(5, 1.5+0.14*sum(marker_metadata$used_for_clustering)),
+    h = min(5, 2+0.14*length(cluster_levels))
+)
 
 # UMAP colored by clusters
 set.seed(1234)
@@ -1109,7 +1113,8 @@ cell_metadata_sub %>%
   theme_classic() +
   scale_color_manual(values=cluster_colors) +
   guides(color=guide_legend(override.aes=list(size=2, alpha=1))) +
-  geom_text(data=label_cell_meta, aes(label=cluster), color="black")
+  geom_text(data=label_cell_meta, aes(label=cluster), color="black") +
+  theme(aspect.ratio = 1, legend.position="none")
 
 
 # Average gene expression heatmap (unscaled)

--- a/cytof_pipeline.R
+++ b/cytof_pipeline.R
@@ -1098,8 +1098,8 @@ dev.off()
 
 pdf(file.path(out_dir, "plots.pdf"),
     # scale by the numbers of markers and clusters to ensure visibility
-    w = min(5, 1.5+0.14*sum(marker_metadata$used_for_clustering)),
-    h = min(5, 2+0.14*length(cluster_levels))
+    w = max(5, 1.5+0.14*sum(marker_metadata$used_for_clustering)),
+    h = max(5, 2+0.14*length(cluster_levels))
 )
 
 # UMAP colored by clusters


### PR DESCRIPTION
1. Sets `silent = T` in a pheatmap call where that was missed
2. Sets the size of 'plots.pdf' to grow with the number of markers and clusters, which ensures the plots stay usable. (also sets aspect.ratio = 1 and hides the legend for the file's umap plot, so that that won't become too rectangular)

ToDo:
- [x] test!